### PR TITLE
Update initialize.py

### DIFF
--- a/dmstudio/initialize.py
+++ b/dmstudio/initialize.py
@@ -124,10 +124,11 @@ def _make_dmdir():
     dmdir_f.write("\n")
 
     for infile in glob.glob("*.dm"):
-        outname = np.str.split(infile, '.')[0]
+        outname = infile.split('.')[0]
         dmdir_f.write('_'+ outname + "_='" + outname + "'\n")
 
     dmdir_f.close()
+
 
 
 


### PR DESCRIPTION
Hello Sean,
An error occurs when attempting to run dmstudio using recent versions of Python. The issue is that "np.str" has been deprecated since NumPy version 1.20. By applying the suggested change, I was able to resolve the problem (I tested it successfully without any issues).